### PR TITLE
Add hotkey to trigger manual restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # voicemeeterRestarter
-This project is a personal tool I use to restart the VoiceMeeter Potato server every 20 minutes, using a tray icon, or using a hotkey (in progress).
+This project is a personal tool I use to restart the VoiceMeeter Potato server every 20 minutes, using a tray icon, or using a hotkey (Ctrl+F9).

--- a/autoRestartVMP.pyw
+++ b/autoRestartVMP.pyw
@@ -11,6 +11,7 @@ import pygetwindow as gw
 import os
 from pywinauto.application import Application
 import argparse
+import keyboard
 
 def main():
     # Start the Tkinter main loop in the main thread
@@ -32,6 +33,9 @@ def main():
     # Minimize the window if the -m/--minimize option was used
     if args.minimize:
         window.after(100, app.minimize)  # Delay the call to minimize
+
+    # Setup hotkeys
+    app.setup_hotkeys()
 
     # Start the Tkinter main loop
     window.mainloop()
@@ -192,7 +196,7 @@ class App:
         # Start the new icon if it's not already running
         self.icon = new_icon
         if not self.icon._running:
-            threading.Thread(target=self.icon.run).start()
+            threading.Thread(target(self.icon.run).start()
 
     from pywinauto.application import Application
 
@@ -206,6 +210,10 @@ class App:
                 app.Voicemeeter.minimize()  # Minimize the window if it's not already minimized
         except Exception as e:
             print(f"Error minimizing Voicemeeter window: {e}")
+
+    def setup_hotkeys(self):
+        # Register the hotkey (Ctrl+F9) to trigger the manual_restart method
+        keyboard.add_hotkey('ctrl+f9', self.manual_restart)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Add a hotkey (Ctrl+F9) to trigger the manual restart function.

* **autoRestartVMP.pyw**
  - Import the `keyboard` module.
  - Add a `setup_hotkeys` method to register the hotkey.
  - Call the `setup_hotkeys` method in the `main` function.
  - Update the `manual_restart` method to be triggered by the hotkey.

* **README.md**
  - Update the `README.md` to reflect the new hotkey feature.

